### PR TITLE
bugfix(MySql): fixed MySql imports

### DIFF
--- a/hugsqlx-core/src/lib.rs
+++ b/hugsqlx-core/src/lib.rs
@@ -31,10 +31,10 @@ impl Context {
                 parse_str::<Type>("sqlx::sqlite::SqliteQueryResult").unwrap(),
             ),
             ContextType::Mysql => Context(
-                parse_str::<Type>("sqlx::mysql::Mysql").unwrap(),
-                parse_str::<Type>("sqlx::mysql::MysqlArguments").unwrap(),
-                parse_str::<Type>("sqlx::mysql::MysqlRow").unwrap(),
-                parse_str::<Type>("sqlx::mysql::MysqlQueryResult").unwrap(),
+                parse_str::<Type>("sqlx::mysql::MySql").unwrap(),
+                parse_str::<Type>("sqlx::mysql::MySqlArguments").unwrap(),
+                parse_str::<Type>("sqlx::mysql::MySqlRow").unwrap(),
+                parse_str::<Type>("sqlx::mysql::MySqlQueryResult").unwrap(),
             ),
             _ => panic!("None of [postgres, sqlite, mysql] feature enabled"),
         }
@@ -329,7 +329,7 @@ cfg_if::cfg_if! {
             ($($arg:expr),*) => {
                 {
                     use sqlx::Arguments;
-                    let mut args = sqlx::mysql::MysqlArguments::default();
+                    let mut args = sqlx::mysql::MySqlArguments::default();
                     $( args.add($arg); )*
                     args
                 }


### PR DESCRIPTION
Hi!

I've noticed that the import names for the `sqlx::mysql` imports were previously incorrect. this PR aims at fixing this.

Without this fix, compiling with the following

```
hugsqlx = {version = "0.1.2", features = [ "mysql" ]}
```

gives the following error:
```
error[E0412]: cannot find type `Mysql` in module `sqlx::mysql`
  --> src/server/database/database_env.rs:14:14
   |
14 |     #[derive(HugSqlx)]
   |              ^^^^^^^ help: a struct with a similar name exists: `MySql`
   |
  ::: /home/vloh/.cargo/registry/src/index.crates.io-6f17d22bba15001f/sqlx-core-0.6.2/src/mysql/database.rs:10:1
   |
10 | pub struct MySql;
   | ---------------- similarly named struct `MySql` defined here
   |
   = note: this error originates in the derive macro `HugSqlx` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0412]: cannot find type `MysqlArguments` in module `sqlx::mysql`
  --> src/server/database/database_env.rs:14:14
   |
14 |     #[derive(HugSqlx)]
   |              ^^^^^^^ help: a struct with a similar name exists: `MySqlArguments`
   |
  ::: /home/vloh/.cargo/registry/src/index.crates.io-6f17d22bba15001f/sqlx-core-0.6.2/src/mysql/arguments.rs:8:1
   |
8  | pub struct MySqlArguments {
   | ------------------------- similarly named struct `MySqlArguments` defined here
   |
   = note: this error originates in the derive macro `HugSqlx` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0412]: cannot find type `MysqlQueryResult` in module `sqlx::mysql`
  --> src/server/database/database_env.rs:14:14
   |
14 |     #[derive(HugSqlx)]
   |              ^^^^^^^ help: a struct with a similar name exists: `MySqlQueryResult`
   |
  ::: /home/vloh/.cargo/registry/src/index.crates.io-6f17d22bba15001f/sqlx-core-0.6.2/src/mysql/query_result.rs:4:1
   |
4  | pub struct MySqlQueryResult {
   | --------------------------- similarly named struct `MySqlQueryResult` defined here
   |
   = note: this error originates in the derive macro `HugSqlx` (in Nightly builds, run with -Z macro-backtrace for more info)
```
